### PR TITLE
Move initial render call to after observer init

### DIFF
--- a/src/observe.ts
+++ b/src/observe.ts
@@ -15,9 +15,6 @@ export default function observe({
   scope: HTMLElement;
   views: Views;
 }): MutationObserver {
-  // Render on load
-  renderTree({ prefix, scope, views });
-
   const observer = new MutationObserver(mutations => {
     mutations.forEach(mutation => {
       const target = mutation.target as DefoHTMLElement;
@@ -88,6 +85,9 @@ export default function observe({
     characterData: false,
     subtree: true
   });
+
+  // Render on load
+  renderTree({ prefix, scope, views });
 
   return observer;
 }


### PR DESCRIPTION
It’s possible for DOM changes made between the initial `renderTree` call and the MutationObserver’s initialisation to be missed. Moving the `renderTree` call to *after* the observer is initialised should help close that gap.